### PR TITLE
break-out-navbar-selects

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,13 +19,9 @@
     <header>
         <nav>
             <a href="index.html" class="active">Home</a>
-            <label for="page-select">Components:
-                <select
-                        _="on change get my options[my selectedIndex] then trigger selected on it"
-                        hx-target="#content"
-                        hx-swap="innerHTML"
-                        id="page-select"
-                >
+            <label for="component-nav-select">
+                <select _="on change get my options[my selectedIndex] then trigger selected on it" hx-target="#content"
+                    hx-swap="innerHTML" class="page-select" id="component-nav-select">
                     <option selected></option>
                     <option hx-get="examples/accordion.html" hx-trigger="selected">Accordion</option>
                     <option hx-get="examples/autocomplete.html" hx-trigger="selected">Autocomplete</option>
@@ -33,11 +29,19 @@
                     <option hx-get="examples/colour.html" hx-trigger="selected">Colour</option>
                     <option hx-get="examples/dialog.html" hx-trigger="selected">Dialog</option>
                     <option hx-get="examples/footnote.html" hx-trigger="selected">Footnote</option>
+                    <option hx-get="examples/switch.html" hx-trigger="selected">Switch</option>
+                </select>
+                <span>Components</span>
+            </label>
+            <label>
+                <select _="on change get my options[my selectedIndex] then trigger selected on it" hx-target="#content"
+                    hx-swap="innerHTML" class="page-select" id="component-nav-select">
+                    <option selected></option>
                     <option hx-get="examples/gradient.html" hx-trigger="selected">Gradient</option>
                     <option hx-get="examples/new-morphism.html" hx-trigger="selected">New Morphism</option>
-                    <option hx-get="examples/switch.html" hx-trigger="selected">Switch</option>
                     <option hx-get="examples/resize.html" hx-trigger="selected">Resize</option>
                 </select>
+                <span>Styles</span>
             </label>
 
             <div class="centred-column">

--- a/static/styles/nav.css
+++ b/static/styles/nav.css
@@ -20,4 +20,21 @@ nav {
         background-color: var(--button-hover-background);
         color: var(--button-color)
     }
+
+    label {
+        display: flex;
+        flex-direction: column-reverse;
+    }
+
+    label>span {
+        font-size: small;
+        transition: all .2s;
+        transform-origin: top left;
+    }
+
+    label>input[placeholder=" "]:not(:focus):placeholder-shown+span {
+        transform: translateY(1em) scale(1.25);
+        pointer-events: none;
+        opacity: .5
+    }
 }


### PR DESCRIPTION
# break-out-navbar-selects

Separated out the component and styls cards and gave them selects of their own with label floating above at reduced font size.

## Visual Changes

### Before

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/e5031612-8010-4545-9abe-308c24c428ba">

### after

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d578ee26-a245-41df-9494-827a9b26c57f">

