### PR TITLE
switch-focus-outline-colour

### DIFF
--- a/static/styles/switch.css
+++ b/static/styles/switch.css
@@ -7,7 +7,7 @@
     width: 2.75rem;
     vertical-align: middle;
     border-radius: 2rem;
-    box-shadow: 0 1px 3px #0003 inset;
+    box-shadow: 0 1px 3px var(--card-shadow) inset;
     transition: 0.25s linear background;
 }
 
@@ -30,11 +30,16 @@
     background: var(--primary-color);
 }
 
+.switch:not(:checked), 
+.switch:not(:checked):focus-visible {
+    background-color: var(--primary-color);
+}
+
 .switch:checked::before {
     transform: translateX(1rem);
 }
 
 .switch:focus-visible {
-    outline: 2px solid dodgerblue;
+    outline: 2px solid var(--primary-color);
     outline-offset: 2px;
 }


### PR DESCRIPTION
# switch-focus-outline-colour

## Visual

### Before

<img width="61" alt="image" src="https://github.com/user-attachments/assets/21702cd6-e9cb-4231-8282-ef93565734a7">

### After

<img width="61" alt="image" src="https://github.com/user-attachments/assets/42fb0980-5b25-4306-8209-6af9f56daa5f">
