### PR TITLE
dank-0002-fix-popover-closing

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script src="static/script.js"></script>
     <header>
         <nav>
-            <button id="nav-menu-button" class="round-icon" popovertarget="nav-menu-popover" popovertargetaction="show">
+            <button id="nav-menu-button" class="round-icon" popovertarget="nav-menu-popover" popovertargetaction="toggle">
                 <img src="static/assets/menu-icon.png" alt="menu icon" class="icon" height="10">
             </button>
             <div id="nav-menu-popover" class="menu-items" popover>

--- a/static/script.js
+++ b/static/script.js
@@ -34,6 +34,9 @@ const switchTheme = {
         const newTheme = event.target.checked ? 'dark' : 'light';
         document.documentElement.setAttribute('data-theme', newTheme);
         localStorage.setItem('theme', newTheme);
+    },
+    add: function(){
+        addGlobalEventListener(this.type, this.selector, this.callback)
     }
 };
 
@@ -42,19 +45,19 @@ const toggleNavPopover = {
     selector: 'select',
     callback: (event) => {
         const selectedClass = event.target.className;
-        console.log(event.target)
         if (selectedClass.match('page-select')) {
             const navMenuPopover = document.getElementById('nav-menu-popover');
             navMenuPopover.togglePopover();
         }
+    },
+    add: function(){
+        addGlobalEventListener(this.type, this.selector, this.callback)
     }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     const themeSwitch = document.getElementById('theme-switch');
     loadPreferredColourScheme(themeSwitch);
-
-    addGlobalEventListener(switchTheme.type, switchTheme.selector, switchTheme.callback);
-
-    addGlobalEventListener(toggleNavPopover.type, toggleNavPopover.selector, toggleNavPopover.callback);
+    switchTheme.add();
+    toggleNavPopover.add();
 });

--- a/static/script.js
+++ b/static/script.js
@@ -17,20 +17,44 @@ function addGlobalEventListener(type, selector, callback, parent = document) {
     });
 }
 
-addGlobalEventListener('click', '#open-dialog-button', (e) => {
-    const modalDialog = document.getElementById('modal-dialog');
-    modalDialog.showModal();
-});
-
-document.addEventListener('DOMContentLoaded', () => {
-    const themeToggleCheckbox = document.getElementById('theme-switch');
+/**
+ * Loads the preferred colour scheme from local storage or the user's system settings and sets the theme accordingly.
+ * @param themeToggleCheckbox {HTMLInputElement} - An <input.switch/> of type checkbox that toggles the theme.
+ */
+function loadPreferredColourScheme(themeToggleCheckbox) {
     const currentTheme = localStorage.getItem('theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
     document.documentElement.setAttribute('data-theme', currentTheme);
     themeToggleCheckbox.checked = currentTheme === 'dark';
+}
 
-    addGlobalEventListener('change', '#theme-switch', () => {
-        const newTheme = themeToggleCheckbox.checked ? 'dark' : 'light';
+const switchTheme = {
+    type: 'change',
+    selector: '#theme-switch',
+    callback: (event) => {
+        const newTheme = event.target.checked ? 'dark' : 'light';
         document.documentElement.setAttribute('data-theme', newTheme);
         localStorage.setItem('theme', newTheme);
-    });
+    }
+};
+
+const toggleNavPopover = {
+    type: 'change',
+    selector: 'select',
+    callback: (event) => {
+        const selectedClass = event.target.className;
+        console.log(event.target)
+        if (selectedClass.match('page-select')) {
+            const navMenuPopover = document.getElementById('nav-menu-popover');
+            navMenuPopover.togglePopover();
+        }
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const themeSwitch = document.getElementById('theme-switch');
+    loadPreferredColourScheme(themeSwitch);
+
+    addGlobalEventListener(switchTheme.type, switchTheme.selector, switchTheme.callback);
+
+    addGlobalEventListener(toggleNavPopover.type, toggleNavPopover.selector, toggleNavPopover.callback);
 });


### PR DESCRIPTION
# dank-0002-fix-popover-closing

## Acceptance Criteria
- Clicking the menu button toggles popover rather shows
- Selecting a page closes the popover

## Other Changes

As a consequence of figuring out the API for popover, I refactored the script js file. The `addGlobalEventListener` function is now passed objects of this kind:

```javascript
const toggleNavPopover = {
    type: 'change',
    selector: 'select',
    callback: (event) => {
        const selectedClass = event.target.className;
        if (selectedClass.match('page-select')) {
            const navMenuPopover = document.getElementById('nav-menu-popover');
            navMenuPopover.togglePopover();
        }
    },
    add: function(){
        addGlobalEventListener(this.type, this.selector, this.callback)
    }
}
```

This, along with a `loadPreferredColourScheme` function to handled the theme setting makes adding behaviours the global event listener of COMContentLoaded simply:

```javascript
document.addEventListener('DOMContentLoaded', () => {
    const themeSwitch = document.getElementById('theme-switch');
    loadPreferredColourScheme(themeSwitch);
    switchTheme.add();
    toggleNavPopover.add();
});
```